### PR TITLE
Adding room owner administrator to the DB

### DIFF
--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -4,6 +4,8 @@ import { ChannelModule } from './channel/channel.module';
 import { MessageModule } from './message/message.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { RoomEntity } from './room/entities/room.entity';
+import { User } from '../user/user.entity';
+import { UserToRoomEntity } from './room/entities/user.to.room.entity';
 import { RoomService } from './room/room.service';
 import { AuthModule } from '../auth/auth.module';
 import { ConnectedUserService } from './connected-user/connected-user.service';
@@ -21,6 +23,8 @@ import { UserModule } from 'src/user/user.module';
 		MessageModule,
 		TypeOrmModule.forFeature([
 			RoomEntity,
+			User,
+			UserToRoomEntity,
 			ConnectedUserEntity,
 			MessageEntity,
 		]),

--- a/backend/src/chat/room/dto/create.room.dto.ts
+++ b/backend/src/chat/room/dto/create.room.dto.ts
@@ -1,6 +1,5 @@
 import {
 	IsBoolean,
-	IsEmpty,
 	IsEnum,
 	IsNotEmpty,
 	IsString,
@@ -9,8 +8,7 @@ import {
 	MinLength,
 	ValidateIf,
 } from 'class-validator';
-import { RoomVisibilityType } from '../entities/room.entity';
-import { UserI } from 'src/user/user.interface';
+import { RoomVisibilityType } from '../enums/room.visibility.enum';
 
 export class createRoomDto {
 	@IsNotEmpty()
@@ -48,7 +46,4 @@ export class createRoomDto {
 		},
 	}) // Maximum password length should not be set too low, as it will prevent users from creating passphrases
 	password: string;
-
-	@IsEmpty()
-	users?: UserI[];
 }

--- a/backend/src/chat/room/dto/index.ts
+++ b/backend/src/chat/room/dto/index.ts
@@ -1,1 +1,2 @@
-export * from './createRoom.dto';
+export * from './create.room.dto';
+export * from './room.for.user.dto';

--- a/backend/src/chat/room/dto/room.for.user.dto.ts
+++ b/backend/src/chat/room/dto/room.for.user.dto.ts
@@ -1,0 +1,18 @@
+import { Exclude, Expose } from 'class-transformer';
+import { RoomVisibilityType } from '../enums/room.visibility.enum';
+import { UserRole } from '../enums/user.role.enum';
+
+@Exclude()
+export class RoomForUserDto {
+	@Expose()
+	readonly name: string;
+
+	@Expose()
+	readonly visibility: RoomVisibilityType;
+
+	@Expose()
+	protected: boolean;
+
+	@Expose()
+	userRole: UserRole;
+}

--- a/backend/src/chat/room/entities/room.entity.ts
+++ b/backend/src/chat/room/entities/room.entity.ts
@@ -1,18 +1,8 @@
 import { MessageEntity } from 'src/chat/message/message.entity';
-import User from 'src/user/user.entity';
-import {
-	Column,
-	Entity,
-	JoinTable,
-	ManyToMany,
-	OneToMany,
-	PrimaryGeneratedColumn,
-} from 'typeorm';
-
-export enum RoomVisibilityType {
-	PUBLIC,
-	PRIVATE,
-}
+import { RoomVisibilityType } from '../enums/room.visibility.enum';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { UserToRoomEntity } from './user.to.room.entity';
+import { Exclude } from 'class-transformer';
 
 @Entity()
 export class RoomEntity {
@@ -30,11 +20,13 @@ export class RoomEntity {
 	visibility: RoomVisibilityType;
 
 	@Column({ nullable: true })
+	@Exclude()
 	password: string;
 
-	@ManyToMany(() => User, (user) => user.rooms, { cascade: true }) //  describes relationship: multiple instances of rooms can contain multiple users and vv
-	@JoinTable() //  is required for @ManyToMany relations. You must put @JoinTable on one (owning) side of relation.
-	users: User[];
+	@OneToMany(() => UserToRoomEntity, (userToRoom) => userToRoom.room, {
+		cascade: true,
+	})
+	public userToRooms!: UserToRoomEntity[];
 
 	@OneToMany(() => MessageEntity, (message) => message.room)
 	messages: MessageEntity[];

--- a/backend/src/chat/room/entities/user.to.room.entity.ts
+++ b/backend/src/chat/room/entities/user.to.room.entity.ts
@@ -1,0 +1,33 @@
+import {
+	Column,
+	Entity,
+	ManyToOne,
+	PrimaryGeneratedColumn,
+	JoinColumn,
+} from 'typeorm';
+import User from 'src/user/user.entity';
+import { RoomEntity } from './room.entity';
+import { UserRole } from '../enums/user.role.enum';
+
+@Entity()
+export class UserToRoomEntity {
+	@PrimaryGeneratedColumn()
+	id!: number;
+
+	@Column()
+	public userId!: number;
+
+	@Column()
+	public roomId!: number;
+
+	@Column()
+	public role!: UserRole;
+
+	@ManyToOne(() => User, (user) => user.userToRooms)
+	@JoinColumn({ name: 'userId' })
+	public user!: User;
+
+	@ManyToOne(() => RoomEntity, (room) => room.userToRooms)
+	@JoinColumn({ name: 'roomId' })
+	public room!: RoomEntity;
+}

--- a/backend/src/chat/room/enums/room.visibility.enum.ts
+++ b/backend/src/chat/room/enums/room.visibility.enum.ts
@@ -1,0 +1,4 @@
+export enum RoomVisibilityType {
+	PUBLIC,
+	PRIVATE,
+}

--- a/backend/src/chat/room/enums/user.role.enum.ts
+++ b/backend/src/chat/room/enums/user.role.enum.ts
@@ -1,0 +1,6 @@
+export enum UserRole {
+	OWNER,
+	ADMIN,
+	VISITOR,
+	BLOCKED, // TODO probably separate relationship for blocked users needed
+}

--- a/backend/src/chat/room/room.interface.ts
+++ b/backend/src/chat/room/room.interface.ts
@@ -1,4 +1,4 @@
-import { RoomVisibilityType } from './entities/room.entity';
+import { RoomVisibilityType } from './enums/room.visibility.enum';
 import { UserI } from 'src/user/user.interface';
 
 export interface RoomI {

--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -2,12 +2,14 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, getRepository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
-import { RoomEntity, RoomVisibilityType } from './entities/room.entity';
-import { RoomI } from './room.interface';
+import { RoomEntity } from './entities/room.entity';
+import { RoomVisibilityType } from './enums/room.visibility.enum';
 import { UserI } from 'src/user/user.interface';
 import { User } from 'src/user/user.entity';
 import { UserService } from '../../user/user.service';
 import { createRoomDto } from './dto';
+import { UserToRoomEntity } from './entities/user.to.room.entity';
+import { UserRole } from './enums/user.role.enum';
 
 @Injectable()
 export class RoomService {
@@ -15,84 +17,139 @@ export class RoomService {
 		@Inject(forwardRef(() => UserService))
 		private readonly userService: UserService,
 		@InjectRepository(RoomEntity)
-		private readonly RoomEntityRepository: Repository<RoomEntity>, // private readonly UserService: UserService,
+		private readonly roomEntityRepository: Repository<RoomEntity>,
+		@InjectRepository(User)
+		private readonly userEntityRepository: Repository<User>,
+		@InjectRepository(UserToRoomEntity)
+		private readonly userToroomEntityRepository: Repository<UserToRoomEntity>,
 	) {}
 
-	async findByName(roomName: string): Promise<RoomI> {
-		return await this.RoomEntityRepository.findOne({
+	async findRoomById(roomId: number): Promise<RoomEntity> {
+		return await this.roomEntityRepository.findOne({
+			where: { id: roomId },
+		});
+	}
+
+	async findRoomByName(roomName: string): Promise<RoomEntity> {
+		return await this.roomEntityRepository.findOne({
 			where: { name: roomName },
 		});
 	}
 
-	async createRoom(
-		room: createRoomDto,
+	async createNewRoom(
+		roomPayload: createRoomDto,
 		userToAddToRoom: UserI,
-	): Promise<{ status: string; data: string }> {
-		room.users = [];
-		const newRoom = await this.addUserToRoom(room, userToAddToRoom); // adding current creator to the array of users for this new room
-		if (room.password !== null) {
-			const hash = await this.encryptRoomPassword(room.password);
-			room.password = hash;
+	): Promise<RoomEntity | undefined> {
+		const newRoom = this.roomEntityRepository.create(roomPayload);
+		newRoom.name = roomPayload.name;
+		newRoom.visibility = roomPayload.visibility;
+		if (roomPayload.password !== null) {
+			newRoom.password = await this.setRoomPassword(roomPayload.password);
+		} else {
+			newRoom.password = null;
 		}
-		const response = {
-			status: '',
-			data: '',
-		};
 		try {
-			await this.RoomEntityRepository.save(newRoom); // Saves a given entity in the database if the new room name doesn't exist.
-			response.status = 'OK';
-			response.data = `${newRoom.name}`;
+			await this.roomEntityRepository.save(newRoom); // Saves a given entity in the database if the new room name doesn't exist.
+			await this.createManyToManyRelationship(
+				newRoom,
+				userToAddToRoom,
+				UserRole.OWNER,
+			);
 		} catch (err) {
 			// if promise rejects (in case the name is not unique,23505 - is the PostrgreSQL error code for unique constraint violation)
 			if (err.code === '23505') {
-				response.status = 'ERROR';
-				response.data = `${newRoom.name}`;
+				return undefined;
 			}
+		}
+		return newRoom;
+	}
+
+	//FIXME: create one function that will throw exception which will be caught on frontend
+	async createRoom(
+		roomPayload: createRoomDto,
+		userToAddToRoom: UserI,
+	): Promise<{ status: string; data: string }> {
+		const newRoom = await this.createNewRoom(roomPayload, userToAddToRoom);
+		const response = {
+			status: '',
+			data: `${newRoom.name}`,
+		};
+		if (newRoom) {
+			response.status = 'OK';
+		} else {
+			response.status = 'ERROR';
 		}
 		return response;
 	}
 
+	async createManyToManyRelationship(
+		newRoom: RoomEntity,
+		userToAddToRoom: UserI,
+		userRole: UserRole,
+	) {
+		const userToRoom: UserToRoomEntity =
+			this.userToroomEntityRepository.create();
+		//FIXME: temp workaround getting user of type UserEntity instead of UserI
+		const user: User = await this.userEntityRepository.findOne({
+			where: { id: userToAddToRoom.id },
+		});
+		userToRoom.user = user;
+		userToRoom.room = newRoom;
+		userToRoom.role = userRole;
+		await this.userToroomEntityRepository.save(userToRoom);
+	}
+
+	async getDefaultRoom() {
+		let defaultRoom: RoomEntity | undefined = await this.findRoomById(1);
+		if (defaultRoom === undefined) {
+			defaultRoom = await this.createDefaultRoom();
+		}
+		return defaultRoom;
+	}
+
 	async createDefaultRoom() {
 		const defaultUser = await this.userService.createDefaultUser();
-		await this.createRoom(
+		return await this.createNewRoom(
 			{
 				name: 'general',
 				isDirectMessage: false,
 				visibility: RoomVisibilityType.PUBLIC,
 				password: null,
-				users: [],
 			},
 			defaultUser,
 		);
 	}
 
-	async updateRoom(roomToUpdate: RoomI) {
-		await this.RoomEntityRepository.save(roomToUpdate);
+	async updateRoom(roomToUpdate: RoomEntity) {
+		await this.roomEntityRepository.save(roomToUpdate);
 	}
 
-	async addUserToRoom(room: RoomI, userToAddToRoom: UserI): Promise<RoomI> {
-		room.users.push(userToAddToRoom);
-		return room;
+	async addVisitorToRoom(userToAddToRoom: UserI, room: RoomEntity) {
+		await this.createManyToManyRelationship(
+			room,
+			userToAddToRoom,
+			UserRole.VISITOR,
+		);
 	}
 
-	async getRoomsForUser(userId: number): Promise<RoomI[]> {
+	async getRoomsForUser(userId: number): Promise<RoomEntity[]> {
 		//build SQL query to get rooms
 		// leftJoin will be referencing the property 'users' defined in the RoomEntity.
 		const userRooms = await getRepository(RoomEntity)
 			.createQueryBuilder('room')
-			.leftJoinAndSelect('room.users', 'user')
+			.leftJoinAndSelect('room.userToRooms', 'userToRooms')
+			.leftJoinAndSelect('userToRooms.user', 'user')
 			.where('user.id = :userId', { userId })
 			.getMany();
 		return userRooms;
 	}
 
-	async getUsersForRoom(roomName: string): Promise<UserI[]> {
-		const usersInRoom = await getRepository(User)
-			.createQueryBuilder('user')
-			.leftJoinAndSelect('user.rooms', 'room')
-			.where('room.name = :roomName', { roomName })
-			.getMany();
-		return usersInRoom;
+	async setRoomPassword(roomPassword: string | null): Promise<string | null> {
+		if (!roomPassword === null) {
+			return null;
+		}
+		const hash = await this.encryptRoomPassword(roomPassword);
+		return hash;
 	}
 
 	async encryptRoomPassword(password: string): Promise<string> {

--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -85,9 +85,7 @@ export class RoomService {
 		const userToRoom: UserToRoomEntity =
 			this.userToroomEntityRepository.create();
 		//FIXME: temp workaround getting user of type UserEntity instead of UserI. Will be replaced with UserEntity
-		const user: User = await this.userEntityRepository.findOne({
-			where: { id: userIdToAdd },
-		});
+		const user: User = await this.userService.getUserByID(userIdToAdd);
 		userToRoom.user = user;
 		userToRoom.room = newRoom;
 		userToRoom.role = userRole;
@@ -115,6 +113,20 @@ export class RoomService {
 		);
 	}
 
+	// TODO: remove this temp room for testing protected
+	async createDefaultProtectedRoom() {
+		const defaultUser: User = await this.userService.getUserByID(1);
+		return await this.createAndSaveNewRoom(
+			{
+				name: 'general protected',
+				isDirectMessage: false,
+				visibility: RoomVisibilityType.PUBLIC,
+				password: '1',
+			},
+			defaultUser.id,
+		);
+	}
+
 	async updateRoom(roomToUpdate: RoomEntity) {
 		await this.roomEntityRepository.save(roomToUpdate);
 	}
@@ -125,6 +137,7 @@ export class RoomService {
 			userToAddId,
 			UserRole.VISITOR,
 		);
+		await this.roomEntityRepository.save(room);
 	}
 
 	async getRoomsForUser(userId: number): Promise<RoomEntity[]> {

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -71,7 +71,7 @@ export class ChatGateway
 
 	@SubscribeMessage('addMessage') //allows to listen to incoming messages
 	async handleMessage(client: Socket, message: MessageI) {
-		const selectedRoom: RoomI = await this.roomService.findByName(
+		const selectedRoom: RoomEntity = await this.roomService.findRoomByName(
 			message.room.name,
 		);
 		const createdMessage: MessageI = await this.messageService.create(

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -89,7 +89,7 @@ export class ChatGateway
 		@ConnectedSocket() client: Socket,
 	) {
 		const response: { status: string; data: string } =
-			await this.roomService.createRoom(room, client.data.user);
+			await this.roomService.createRoom(room, client.data.user.id);
 		client.emit('createRoom', response);
 	}
 

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,11 +1,11 @@
 import { ConnectedUserEntity } from 'src/chat/connected-user/connected-user.entity';
 import { MessageEntity } from 'src/chat/message/message.entity';
-import { RoomEntity } from 'src/chat/room/entities/room.entity';
+import { UserToRoomEntity } from '../chat/room/entities/user.to.room.entity';
+
 import {
 	Column,
 	Entity,
 	JoinColumn,
-	ManyToMany,
 	OneToMany,
 	PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -28,8 +28,10 @@ export class User {
 	@OneToMany(() => ConnectedUserEntity, (connection) => connection.user)
 	connections: ConnectedUserEntity[];
 
-	@ManyToMany(() => RoomEntity, (room) => room.users)
-	rooms: RoomEntity[];
+	@OneToMany(() => UserToRoomEntity, (userToRoom) => userToRoom.room, {
+		cascade: true,
+	})
+	public userToRooms!: UserToRoomEntity[];
 
 	@OneToMany(() => MessageEntity, (message) => message.user)
 	messages: MessageEntity[];

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -31,7 +31,7 @@ export class UserService {
 		const defaultRoom: RoomEntity = await this.roomService.getDefaultRoom();
 		const newUser = this.userRepository.create(userData);
 		const createdUser: UserI = await this.userRepository.save(newUser);
-		await this.roomService.addVisitorToRoom(createdUser, defaultRoom);
+		await this.roomService.addVisitorToRoom(createdUser.id, defaultRoom);
 		await this.roomService.updateRoom(defaultRoom);
 		return createdUser;
 	}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -21,6 +21,13 @@ export class UserService {
 		});
 	}
 
+	//FIXME: this is a kind of duplicate findOne function to return User entity instead of UserI
+	async getUserByID(idToFind: number): Promise<User> {
+		return await this.userRepository.findOne({
+			where: { id: idToFind },
+		});
+	}
+
 	async findByIntraID(intraID: string): Promise<UserI> {
 		return await this.userRepository.findOne({ intraID });
 	}
@@ -32,7 +39,15 @@ export class UserService {
 		const newUser = this.userRepository.create(userData);
 		const createdUser: UserI = await this.userRepository.save(newUser);
 		await this.roomService.addVisitorToRoom(createdUser.id, defaultRoom);
-		await this.roomService.updateRoom(defaultRoom);
+
+		//FIXME: temp for testing protected rooms:
+		const protectedWithPassword: RoomEntity =
+			await this.roomService.createDefaultProtectedRoom();
+		await this.roomService.addVisitorToRoom(
+			createdUser.id,
+			protectedWithPassword,
+		);
+
 		return createdUser;
 	}
 

--- a/frontend/src/components/ChatRoomsList.vue
+++ b/frontend/src/components/ChatRoomsList.vue
@@ -21,7 +21,7 @@
         <template #body="slotProps">
           <div>
             <i
-              v-if="slotProps.data.password !== null"
+              v-if="slotProps.data.protected"
               class="pi pi-shield"
               style="font-size: 0.8rem"
             ></i>
@@ -62,6 +62,8 @@ onMounted(() => {
     socket.emit("getUserRoomsList");
   }, 90); // FIXME: find a better solution?
   socket.on("getUserRoomsList", (response) => {
+    console.log("rooms from server", response);
+
     rooms.value = response;
   });
 });
@@ -75,14 +77,14 @@ const selectedRoomName = ref("");
 // const selectedRoomIcon = ref("pi pi-hashtag");
 
 const onRowSelect = (event) => {
-  if (event.data.password !== null) {
+  const room = event.data;
+  if (room.protected && room.userRole !== 0) {
     displayPasswordDialog.value = true;
-    selectedRoomName.value = event.data.name;
-    // selectedRoomIcon.value = "pi pi-hashtag"; // TODO: update
+    selectedRoomName.value = room.name;
   } else {
     router.push({
       name: "ChatBox",
-      params: { roomName: event.data.name },
+      params: { roomName: room.name },
     });
   }
 };


### PR DESCRIPTION
This part is mostly about handling ManyToMany relationship with custom column and replacing RoomI interface on backend by RoomEntity objects or Dto.
I needed the additional column to mark the User role in the current room (owner, admin, visitor, blocked).

Atm you can see the client-side the console log  with the information about the `user role` as well. For the testing purposes I've added the temporary `general protected` room with the password '1' owned by the default user.  It requires the password from anyone who's not the owner (this logic will also be changed later). But if you create your own protected room (when creating it just specify the password) you won't have to enter the password because you're the owner.