### PR TITLE
Context menu for user in chat

### DIFF
--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -20,7 +20,7 @@
                 class="user"
                 :label="m.user.username"
                 :image="m.user.avatar"
-                @contextmenu="onChipRightClick"
+                @contextmenu="onChipRightClick(m.user.id)"
               />
               <Chip class="time" :label="moment(m.created_at).format('LT')" />
             </div>
@@ -57,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, onMounted, onUnmounted } from "vue";
+import { ref, inject, onMounted, onUnmounted, computed } from "vue";
 import { Socket } from "socket.io-client";
 import MessageI from "../types/Message.interface";
 import Card from "primevue/card";
@@ -73,11 +73,20 @@ const socket: Socket = inject("socketioInstance");
 const messages = ref<Array<MessageI>>([]);
 const input = ref<string>("");
 const route = useRoute();
+const clickedUserID = ref<number>(1);
+const id = computed(() => {
+  return clickedUserID.value;
+}); //items ref params need a calculated property
+
 const menu = ref();
 const items = ref([
   {
     label: "View profile",
     icon: "pi pi-fw pi-user",
+    to: {
+      name: "UserProfileCard",
+      params: { id: id },
+    },
   },
   {
     separator: true,
@@ -87,10 +96,6 @@ const items = ref([
     icon: "pi pi-fw pi-caret-right",
   },
 ]);
-
-const onChipRightClick = (event: Event) => {
-  menu.value.show(event);
-};
 
 onMounted(() => {
   socket.emit("getMessagesForRoom", route.params.roomName); //emit to load once it's mounted
@@ -119,6 +124,11 @@ function sendMessage() {
     });
   input.value = "";
 }
+
+function onChipRightClick(userID: number) {
+  clickedUserID.value = userID;
+  menu.value.show(event);
+} //shows ContextMenu when UserChip is right clicked and reassigns the ID value
 </script>
 
 <style scoped>

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -88,7 +88,7 @@ const items = ref([
   },
 ]);
 
-const onChipRightClick = (event) => {
+const onChipRightClick = (event: Event) => {
   menu.value.show(event);
 };
 
@@ -138,6 +138,11 @@ function sendMessage() {
 .p-chip.user {
   font-size: 50%;
   height: 2vh;
+}
+
+.p-chip.user:hover {
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 .p-chip.time {

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -3,6 +3,7 @@
     <Panel>
       {{ $route.params.roomName }}
     </Panel>
+    <ContextMenu ref="menu" :model="items" />
     <div
       id="all-messages"
       class="flex flex-column-reverse gap-1 md:gap-2 xl:gap-4"
@@ -21,7 +22,6 @@
                 :image="m.user.avatar"
                 @contextmenu="onChipRightClick"
               />
-              <ContextMenu ref="menu" :model="items" />
               <Chip class="time" :label="moment(m.created_at).format('LT')" />
             </div>
           </template>
@@ -76,15 +76,19 @@ const route = useRoute();
 const menu = ref();
 const items = ref([
   {
-    label: "Quit",
-    icon: "pi pi-fw pi-power-off",
+    label: "View profile",
+    icon: "pi pi-fw pi-user",
+  },
+  {
+    separator: true,
+  },
+  {
+    label: "Play pong",
+    icon: "pi pi-fw pi-caret-right",
   },
 ]);
 
 const onChipRightClick = (event) => {
-  console.log(menu.value);
-  console.log(event);
-  console.log(items.value);
   menu.value.show(event);
 };
 
@@ -115,10 +119,6 @@ function sendMessage() {
     });
   input.value = "";
 }
-
-// function onChipRightClick((event) => {
-//   menu.value.show(event);
-// })
 </script>
 
 <style scoped>

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -74,7 +74,7 @@ const messages = ref<Array<MessageI>>([]);
 const input = ref<string>("");
 const route = useRoute();
 const clickedUserID = ref<number>(1);
-const id = computed(() => {
+const computedID = computed(() => {
   return clickedUserID.value;
 }); //items ref params need a calculated property
 
@@ -85,7 +85,7 @@ const items = ref([
     icon: "pi pi-fw pi-user",
     to: {
       name: "UserProfileCard",
-      params: { id: id },
+      params: { id: computedID },
     },
   },
   {

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -19,7 +19,9 @@
                 class="user"
                 :label="m.user.username"
                 :image="m.user.avatar"
+                @contextmenu="onChipRightClick"
               />
+              <ContextMenu ref="menu" :model="items" />
               <Chip class="time" :label="moment(m.created_at).format('LT')" />
             </div>
           </template>
@@ -65,11 +67,26 @@ import Panel from "primevue/panel";
 import { useRoute } from "vue-router";
 import moment from "moment";
 import Chip from "primevue/chip";
+import ContextMenu from "primevue/contextmenu";
 
 const socket: Socket = inject("socketioInstance");
 const messages = ref<Array<MessageI>>([]);
 const input = ref<string>("");
 const route = useRoute();
+const menu = ref();
+const items = ref([
+  {
+    label: "Quit",
+    icon: "pi pi-fw pi-power-off",
+  },
+]);
+
+const onChipRightClick = (event) => {
+  console.log(menu.value);
+  console.log(event);
+  console.log(items.value);
+  menu.value.show(event);
+};
 
 onMounted(() => {
   socket.emit("getMessagesForRoom", route.params.roomName); //emit to load once it's mounted
@@ -98,6 +115,10 @@ function sendMessage() {
     });
   input.value = "";
 }
+
+// function onChipRightClick((event) => {
+//   menu.value.show(event);
+// })
 </script>
 
 <style scoped>

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -94,7 +94,7 @@ const items = ref([
   {
     label: "Play pong",
     icon: "pi pi-fw pi-caret-right",
-  },
+  }, //TODO add a View to play game when we have it ready
 ]);
 
 onMounted(() => {


### PR DESCRIPTION
Only FrontEnd PR

- ContextMenu primevue component is added 
- The const menu and const items properties for ContextMenu are added
- items -> label -> to -> params property needed a user id to route to the user's profile and this value changes depending on which user avatar/chip is clicked. That's why I needed to use a value of a reactive object (id) inside another reactive object (items). I have decied to use computed property for this. See [https://stackoverflow.com/questions/68472977/how-to-set-the-value-of-a-reactive-object-ref-with-a-value-from-another-reacti](url)
- onChipRightClick functions shows the context menu and changes the clickedUserID value
- When User Chip is hovered the user name gets underlined and the cursor transforms to a pointer to indicate a context menu. See slack username hover for example.

Sources:
[https://www.primefaces.org/primevue/contextmenu](url)


TODO
A View will be added to items once we have the Game part 