### PR TITLE
Room context menu

### DIFF
--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -177,8 +177,6 @@ export class RoomService {
 			.orderBy('userToRooms.role')
 			.addOrderBy('room.name')
 			.getMany();
-		console.log('User Rooms: \n', userRooms);
-
 		return userRooms;
 	}
 

--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -54,11 +54,7 @@ export class RoomService {
 		const newRoom = this.roomEntityRepository.create(roomPayload);
 		newRoom.name = roomPayload.name;
 		newRoom.visibility = roomPayload.visibility;
-		if (roomPayload.password !== null) {
-			newRoom.password = await this.setRoomPassword(roomPayload.password);
-		} else {
-			newRoom.password = null;
-		}
+		newRoom.password = await this.setRoomPassword(roomPayload.password);
 		try {
 			await this.roomEntityRepository.save(newRoom); // Saves a given entity in the database if the new room name doesn't exist.
 			// manyToOne and oneToMany with additional userToRoomEntity makes manyToMany relationship
@@ -192,8 +188,13 @@ export class RoomService {
 		return userRooms;
 	}
 
+	async updateRoomPassword(room: RoomEntity, newPassword: string | null) {
+		room.password = await this.setRoomPassword(newPassword);
+		await this.roomEntityRepository.save(room);
+	}
+
 	async setRoomPassword(roomPassword: string | null): Promise<string | null> {
-		if (!roomPassword === null) {
+		if (roomPassword === null) {
 			return null;
 		}
 		const hash = await this.encryptRoomPassword(roomPassword);

--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -87,11 +87,6 @@ export class RoomService {
 		await this.userToroomEntityRepository.save(userToRoom);
 	}
 
-	// async deleteUserRoomRelationship(
-	// 	newRoom: RoomEntity,
-	// 	userToRemoveId: number,
-	// ) {}
-
 	async getDefaultRoom() {
 		let defaultRoom: RoomEntity | undefined = await this.findRoomById(1);
 		if (defaultRoom === undefined) {
@@ -214,6 +209,4 @@ export class RoomService {
 		const isMatch = await bcrypt.compare(password, hash);
 		return isMatch;
 	}
-
-	// async unlockProtectedRoom() {}
 }

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -127,17 +127,20 @@ export class ChatGateway
 
 	@SubscribeMessage('getUserRoomsList')
 	async getUserRoomsList(client: Socket) {
-		const roomEntities: RoomEntity[] =
-			await this.roomService.getRoomsForUser(client.data.user.id);
-		// we don't need all information from the RoomEntity returned to the user, we'll have to serialize it
-		// by converting roomentity type to dto with several excluded and transformed properties
-		const response: RoomForUserDto[] = roomEntities.map((room) => {
-			const listedRoom = plainToClass(RoomForUserDto, room); //
-			listedRoom.userRole = room.userToRooms[0].role; // getting role from userToRooms array
-			listedRoom.protected = room.password ? true : false; // we don't pass the password back to user
-			return listedRoom;
-		});
-		client.emit('getUserRoomsList', response);
+		if (client.data.user) {
+			const roomEntities: RoomEntity[] =
+				await this.roomService.getRoomsForUser(client.data.user.id);
+
+			// we don't need all information from the RoomEntity returned to the user, we'll have to serialize it
+			// by converting roomentity type to dto with several excluded and transformed properties
+			const response: RoomForUserDto[] = roomEntities.map((room) => {
+				const listedRoom = plainToClass(RoomForUserDto, room); //
+				listedRoom.userRole = room.userToRooms[0].role; // getting role from userToRooms array
+				listedRoom.protected = room.password ? true : false; // we don't pass the password back to user
+				return listedRoom;
+			});
+			client.emit('getUserRoomsList', response);
+		}
 	}
 
 	@SubscribeMessage('addUserToRoom')
@@ -150,6 +153,7 @@ export class ChatGateway
 		);
 		await this.roomService.addVisitorToRoom(client.data.user.id, room);
 		client.join(room.name);
+		client.emit('updateUserInRoom');
 	}
 
 	@SubscribeMessage('removeUserFromRoom')
@@ -164,6 +168,7 @@ export class ChatGateway
 			client.data.user.id,
 			room,
 		);
+		client.emit('updateUserInRoom');
 	}
 
 	@SubscribeMessage('checkRoomPasswordMatch')

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -146,6 +146,20 @@ export class ChatGateway
 		await this.roomService.addVisitorToRoom(client.data.user.id, room);
 	}
 
+	@SubscribeMessage('removeUserFromRoom')
+	async removeUserFromRoom(
+		@MessageBody() roomName: string,
+		@ConnectedSocket() client: Socket,
+	) {
+		const room: RoomEntity = await this.roomService.findRoomByName(
+			roomName,
+		);
+		await this.roomService.deleteUserRoomRelationship(
+			client.data.user.id,
+			room,
+		);
+	}
+
 	@SubscribeMessage('checkRoomPasswordMatch')
 	async checkRoomPasswordMatch(
 		client: Socket,

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -143,6 +143,18 @@ export class ChatGateway
 		}
 	}
 
+	@SubscribeMessage('updateRoomPassword')
+	async updateRoomPassword(
+		@ConnectedSocket() client: Socket,
+		@MessageBody() roomToUpdate: { name: string; password: string },
+	) {
+		const room: RoomEntity = await this.roomService.findRoomByName(
+			roomToUpdate.name,
+		);
+		await this.roomService.updateRoomPassword(room, roomToUpdate.password);
+		await this.getPublicRoomsList(client);
+	}
+
 	@SubscribeMessage('addUserToRoom')
 	async addUserToRoom(
 		@MessageBody() roomName: string,

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -153,7 +153,7 @@ export class ChatGateway
 		);
 		await this.roomService.addVisitorToRoom(client.data.user.id, room);
 		client.join(room.name);
-		client.emit('updateUserInRoom');
+		await this.getPublicRoomsList(client);
 	}
 
 	@SubscribeMessage('removeUserFromRoom')
@@ -168,7 +168,7 @@ export class ChatGateway
 			client.data.user.id,
 			room,
 		);
-		client.emit('updateUserInRoom');
+		await this.getPublicRoomsList(client);
 	}
 
 	@SubscribeMessage('checkRoomPasswordMatch')

--- a/frontend/src/components/ChatRoomEditPrivacyDialogue.vue
+++ b/frontend/src/components/ChatRoomEditPrivacyDialogue.vue
@@ -1,0 +1,98 @@
+<template>
+  <Dialog
+    header="Edit Room Privacy"
+    :visible="isDialogVisible"
+    closeOnEscape
+    :style="{ width: '50vw' }"
+    :closable="false"
+  >
+    <div class="field p-fluid">
+      <small v-if="props.room.protected" id="password-help"
+        >Change the '{{ room.name }}' room password.</small
+      >
+      <small v-else id="password-help"
+        >Protect your '{{ room.name }}' with a password</small
+      >
+      <BlockUI :blocked="removePasswordChecked">
+        <Password
+          id="password"
+          v-model="passwordValue"
+          :feedback="true"
+          toggleMask
+        />
+      </BlockUI>
+    </div>
+    <template #footer>
+      <div class="mt-3">
+        <div v-if="props.room.protected" class="field-checkbox">
+          <Checkbox
+            id="remove-password"
+            v-model="removePasswordChecked"
+            :binary="true"
+            @change="showValue"
+          />
+          <label for="remove-password">Remove password</label>
+        </div>
+        <Button
+          label="Cancel"
+          icon="pi pi-times"
+          @click="closePasswordDialog"
+          class="p-button-text"
+        />
+        <Button
+          v-if="props.room.protected"
+          label="Update"
+          icon="pi pi-check"
+          @click="updateRoomPassword"
+          autofocus
+        />
+        <Button
+          v-else
+          label="Set password"
+          icon="pi pi-check"
+          @click="updateRoomPassword"
+          autofocus
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, inject, defineEmits, defineProps } from "vue";
+import { Socket } from "socket.io-client";
+import Dialog from "primevue/dialog";
+import Password from "primevue/password";
+import Button from "primevue/button";
+import Checkbox from "primevue/checkbox";
+import BlockUI from "primevue/blockui";
+
+const socket: Socket = inject("socketioInstance");
+
+const props = defineProps(["isDialogVisible", "room"]);
+
+const emit = defineEmits(["update:isDialogVisible"]);
+
+const passwordValue = ref();
+
+const closePasswordDialog = () => {
+  passwordValue.value = null;
+  emit("update:isDialogVisible", false);
+};
+
+const removePasswordChecked = ref<boolean>(false);
+
+const showValue = () =>
+  console.log("IS removePasswordChecked? ", removePasswordChecked.value);
+
+const updateRoomPassword = () => {
+  if (passwordValue.value === "") {
+    passwordValue.value = null;
+  }
+  socket.emit("updateRoomPassword", {
+    name: props.room.name,
+    password: passwordValue.value,
+  });
+  closePasswordDialog();
+};
+</script>

--- a/frontend/src/components/ChatRoomPasswordDialogue.vue
+++ b/frontend/src/components/ChatRoomPasswordDialogue.vue
@@ -47,7 +47,6 @@ import Button from "primevue/button";
 
 const socket: Socket = inject("socketioInstance");
 
-// const props = defineProps(["isDialogVisible", "roomName", "roomIcon"]);
 const props = defineProps(["isDialogVisible", "roomName"]);
 
 const emit = defineEmits(["update:isDialogVisible"]);

--- a/frontend/src/components/ChatRoomsList.vue
+++ b/frontend/src/components/ChatRoomsList.vue
@@ -143,7 +143,7 @@ const menuItems = ref([
 ]);
 
 const onRowContextMenu = (event) => {
-  cm.value.show(event.originalEvent);
+  if (selectedRoom.value.name != "general") cm.value.show(event.originalEvent);
 };
 const isOwner = (userRole: UserRole | undefined) =>
   userRole === 0 ? true : false;

--- a/frontend/src/components/ChatRoomsList.vue
+++ b/frontend/src/components/ChatRoomsList.vue
@@ -6,6 +6,11 @@
       :roomName="selectedRoomName"
       @update:isDialogVisible="displayPasswordDialog = $event"
     />
+    <ChatRoomEditPrivacyDialogue
+      :isDialogVisible="displayEditPrivacyDialog"
+      :room="selectedRoom"
+      @update:isDialogVisible="displayEditPrivacyDialog = $event"
+    />
     <DataTable
       :value="rooms"
       class="p-datatable-sm"
@@ -66,6 +71,7 @@ import { useRouter, useRoute } from "vue-router";
 import { Socket } from "socket.io-client";
 import RoomVisibility from "@/types/RoomVisibility";
 import ChatRoomPasswordDialogue from "./ChatRoomPasswordDialogue.vue";
+import ChatRoomEditPrivacyDialogue from "./ChatRoomEditPrivacyDialogue.vue";
 
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
@@ -84,10 +90,6 @@ setTimeout(() => {
   socket.emit("getPublicRoomsList");
 }, 90); // FIXME: find a better solution?
 
-socket.on("updateUserInRoom", () => {
-  socket.emit("getPublicRoomsList");
-});
-
 socket.on("postPublicRoomsList", (response) => {
   // socket.on("getUserRoomsList", (response) => {
   console.log("rooms from server", response);
@@ -98,6 +100,7 @@ const router = useRouter();
 const route = useRoute();
 
 const displayPasswordDialog = ref(false);
+const displayEditPrivacyDialog = ref(false);
 
 const selectedRoomName = ref("");
 
@@ -120,7 +123,9 @@ const menuItems = ref([
   {
     label: "Edit privacy",
     // icon: "pi pi-pencil",
-    visible: () => isOwner(selectedRoom.value.userRole),
+    visible: () =>
+      selectedRoom.value.visibility === RoomVisibility.PUBLIC &&
+      isOwner(selectedRoom.value.userRole),
     command: () => editRoomPrivacy(selectedRoom),
   },
   {
@@ -179,6 +184,8 @@ const confirmLeave = (room) => {
 };
 
 const editRoomPrivacy = (room) => {
+  displayEditPrivacyDialog.value = true;
+
   console.log(
     `Room ${room.value.name}'s visibility is ${room.value.visibility}. Is it protected with a password? ${room.value.protected}`
   );

--- a/frontend/src/components/ChatRoomsList.vue
+++ b/frontend/src/components/ChatRoomsList.vue
@@ -152,9 +152,7 @@ const confirmLeave = (room) => {
           name: "Chat",
         });
       }
-      console.log(
-        `Let's pretend you've just left the room ${room.value.name}. Check that you're moved to the general room`
-      );
+      socket.emit("removeUserFromRoom", room.value.name);
     },
     reject: () => {
       toast.add({

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,10 +6,14 @@ import "primevue/resources/themes/md-dark-indigo/theme.css"; //theme
 import "primevue/resources/primevue.min.css"; //core css
 import "primeicons/primeicons.css"; //icons
 import "primeflex/primeflex.css"; //PrimeFlex
+import ConfirmationService from "primevue/confirmationservice";
+import ToastService from "primevue/toastservice";
 import storeUser from "@/store";
 
 const app = createApp(App);
 app.use(storeUser);
 app.use(router);
 app.use(PrimeVue);
+app.use(ConfirmationService);
+app.use(ToastService);
 app.mount("#app");

--- a/frontend/src/types/RoomVisibility.ts
+++ b/frontend/src/types/RoomVisibility.ts
@@ -1,7 +1,6 @@
 enum RoomVisibility {
   PUBLIC,
   PRIVATE,
-  PROTECTED,
 }
 
 export default RoomVisibility;

--- a/frontend/src/types/UserRole.Enum.ts
+++ b/frontend/src/types/UserRole.Enum.ts
@@ -1,0 +1,6 @@
+export enum UserRole {
+  OWNER,
+  ADMIN,
+  VISITOR,
+  BLOCKED, // TODO probably separate relationship for blocked users needed
+}

--- a/frontend/src/views/CreateRoomView.vue
+++ b/frontend/src/views/CreateRoomView.vue
@@ -157,6 +157,10 @@ function saveNewRoom() {
     visibility: selectedCategory.value,
     password: passwordValue.value,
   };
+  // setting an empty password value to null:
+  if (newRoom.password === "") {
+    newRoom.password = null;
+  }
   console.log("newRoom data sent from the client: ", newRoom);
   socket.emit("createRoom", newRoom);
   isValidRoomName.value = true;


### PR DESCRIPTION
What has been implemented:
- context menu is appearing on the **right-click**;
- context menu items differ depending on whether a user has joined the room or not and whether he's the room owner;
- if a **user is part of the room** he's having an option to `leave` it => he's kicked out of the room (there is no user icon in that room row any more). A user is pushed to the `default room`.
- **if an owner is leaving the room**, when he joins it again he's `not the owner `any more (the logic behind it will be implemented later: do we transfer the ownership to an admin? do we allow an owner to leave a room if there is noone else inside it? or do we delete this room?)
- **there is no context menu for the default room**, so a user is unable to leave it
- if a user is not part of a room and the room is public a **user can join** it from the context menu (he will be able to view the messages and he's having an input field still, the input field for non-joiners will be replaced by 'Join' button in the future pr's)
- of a user is an **owner of the room** he can see '`Edit privacy`' menu item.
- by clicking it: 
      -  **if the room is locked by the password** he can `update` the password or `remove` it
      - **if it's not locked** he's offered to `set a password`
      - in both cases he's returning to the room he was before and the rooms list is updated (**there can be changes in the room icons if the password has been removed or added**)
     
Additional bugfix:
-https://github.com/42-jkoers/ft_transcendence/issues/95#issue-1272155497