### PR TITLE
Msgs for same user with multiple sockets

### DIFF
--- a/backend/src/chat/channel/channel.module.ts
+++ b/backend/src/chat/channel/channel.module.ts
@@ -1,4 +1,0 @@
-import { Module } from '@nestjs/common';
-
-@Module({})
-export class ChannelModule {}

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -47,6 +47,7 @@ export class ChatGateway
 		);
 		if (user) {
 			console.log(user);
+            // client.join(user.id.toString()); TODO implement this for private messaging
 		} else {
 			console.log('user not authorized.\n'); //FIXME throw an exception
 		}
@@ -57,8 +58,8 @@ export class ChatGateway
 			user,
 		}); // save connection to DB
 		this.server.emit('clientConnected'); // this event needed to prevent rendering frontend components before connection is set //FIXME check
-		client.join('general'); //everyone joins the general on default
-		client.join('general protected'); //everyone joins the general protected
+		// client.join('general'); //everyone joins the general on default
+		// client.join('general protected'); //everyone joins the general protected
 	}
 
 	afterInit() {
@@ -87,6 +88,7 @@ export class ChatGateway
 			selectedRoom,
 		);
 		this.server.to(selectedRoom.name).emit('messageAdded', createdMessage); //server socket emits to all clients
+        //TODO this.server.to(selectedRoom.name).to(user.id.toString()).emit('messageAdded', createdMessage);FOR DM?
 	}
 
 	@SubscribeMessage('getMessagesForRoom')

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -108,6 +108,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			await this.roomService.createRoom(room, client.data.user.id);
 		client.emit('createRoom', response);
 		client.join(response.data);
+		console.log(
+			`first time joining: ${client.data.user.username} w/${client.id} has joined room ${room.name}`,
+		);
 	}
 
 	@SubscribeMessage('getPublicRoomsList')
@@ -166,6 +169,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		);
 		await this.roomService.addVisitorToRoom(client.data.user.id, room);
 		client.join(room.name);
+		console.log(
+			`first time joining: ${client.data.user.username} w/${client.id} has joined room ${room.name}`,
+		);
 		await this.getPublicRoomsList(client);
 	}
 

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -47,7 +47,7 @@ export class ChatGateway
 		);
 		if (user) {
 			console.log(user);
-            // client.join(user.id.toString()); TODO implement this for private messaging
+			// client.join(user.id.toString()); TODO implement this for private messaging
 		} else {
 			console.log('user not authorized.\n'); //FIXME throw an exception
 		}
@@ -60,12 +60,6 @@ export class ChatGateway
 		this.server.emit('clientConnected'); // this event needed to prevent rendering frontend components before connection is set //FIXME check
 		// client.join('general'); //everyone joins the general on default
 		// client.join('general protected'); //everyone joins the general protected
-	}
-
-	afterInit() {
-		this.logger.log('Gateway: init');
-		this.server.emit('Hey there');
-		//TODO maybe delete all connected users and joined rooms with onInit?
 	}
 
 	handleDisconnect(client: Socket) {
@@ -88,7 +82,7 @@ export class ChatGateway
 			selectedRoom,
 		);
 		this.server.to(selectedRoom.name).emit('messageAdded', createdMessage); //server socket emits to all clients
-        //TODO this.server.to(selectedRoom.name).to(user.id.toString()).emit('messageAdded', createdMessage);FOR DM?
+		//TODO this.server.to(selectedRoom.name).to(user.id.toString()).emit('messageAdded', createdMessage);FOR DM?
 	}
 
 	@SubscribeMessage('getMessagesForRoom')

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -63,8 +63,6 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			user,
 		}); // save connection to DB
 		this.server.emit('clientConnected'); // this event needed to prevent rendering frontend components before connection is set //FIXME check
-		// client.join('general'); //everyone joins the general on default
-		// client.join('general protected'); //everyone joins the general protected
 	}
 
 	handleDisconnect(client: Socket) {

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -44,6 +44,14 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		);
 		if (user) {
 			console.log(user);
+			const roomEntities: RoomEntity[] =
+				await this.roomService.getRoomsForUser(user.id);
+			roomEntities.forEach((room) => {
+				client.join(room.name);
+				console.log(
+					`join on connection: ${user.username} w/${client.id} has joined room ${room.name}`,
+				);
+			}); //each new socket connection joins the room that the user is already a part of
 			// client.join(user.id.toString()); TODO implement this for private messaging
 		} else {
 			console.log('user not authorized.\n'); //FIXME throw an exception

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -45,7 +45,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		if (user) {
 			console.log(user);
 			const roomEntities: RoomEntity[] =
-				await this.roomService.getRoomsForUser(user.id);
+				await this.roomService.getRoomsForUser(user.id); //TODO get only room names from room service
 			roomEntities.forEach((room) => {
 				client.join(room.name);
 				console.log(

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -4,7 +4,6 @@ import {
 	MessageBody,
 	OnGatewayConnection,
 	OnGatewayDisconnect,
-	OnGatewayInit,
 	SubscribeMessage,
 	WebSocketGateway,
 	WebSocketServer,
@@ -27,9 +26,7 @@ import { createRoomDto } from '../chat/room/dto';
 @WebSocketGateway({
 	cors: { origin: 'http://localhost:8080', credentials: true },
 }) //allows us to make use of any WebSockets library (in our case socket.io)
-export class ChatGateway
-	implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
-{
+export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 	constructor(
 		private readonly authService: AuthService,
 		private readonly roomService: RoomService,


### PR DESCRIPTION
Changes only in the backend:
- in handleConnection each connected socket of user joins the room that the user is already a part of
- server only emits to the rooms which already has information of which socket ids have joined

- some unused functions and folder have been removed