### PR TITLE
115 add new users to room

### DIFF
--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -35,6 +35,18 @@ export class RoomService {
 		});
 	}
 
+	async getSpecificRoomWithUserToRoomRelations(
+		roomName: string,
+	): Promise<RoomEntity> {
+		const specificRoom = await getRepository(RoomEntity)
+			.createQueryBuilder('room')
+			.where('room.name = :roomName', { roomName })
+			.leftJoinAndSelect('room.userToRooms', 'userToRooms')
+			.leftJoinAndSelect('userToRooms.user', 'user')
+			.getOne();
+		return specificRoom;
+	}
+
 	// emit
 	async createRoom(
 		roomPayload: createRoomDto,

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -53,7 +53,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 					`join on connection: ${user.username} w/${client.id} has joined room ${room.name}`,
 				);
 			}); //each new socket connection joins the room that the user is already a part of
-			// client.join(user.id.toString()); TODO implement this for private messaging
+			client.join(user.id.toString()); //all clients join a unique room called by their ids. this is needed to fetch all sockets of that user
 		} else {
 			console.log('user not authorized.\n'); //FIXME throw an exception
 		}

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -201,12 +201,25 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		client.emit('isRoomPasswordMatched', isMatched);
 	}
 
-	@SubscribeMessage('getNonMemberUsers')
-	async getNonMemberUsers(client: Socket, roomName: string) {
-		const response: UserI[] = await this.userService.getNonMemberUsers(
-			roomName,
+	@SubscribeMessage('getOneRoomWithUserToRoomRelations')
+	async getOneRoomWithUserToRoomRelations(client: Socket, roomName: string) {
+		const room: RoomEntity =
+			await this.roomService.getSpecificRoomWithUserToRoomRelations(
+				roomName,
+			);
+		client.emit('getOneRoomWithUserToRoomRelations', room);
+	}
+
+	@SubscribeMessage('getAllRegisteredUsersExceptYourselfAndAdmin')
+	async getAllRegisteredUsersExceptYourselfAndAdmin(client: Socket) {
+		const user: UserI = await this.userService.findByID(
+			client.data.user.id,
 		);
-		client.emit('getNonMemberUsers', response);
+		const response: UserI[] =
+			await this.userService.getAllRegisteredUsersExceptYourselfAndAdmin(
+				user.username,
+			);
+		client.emit('getAllRegisteredUsersExceptYourselfAndAdmin', response);
 	}
 
 	@SubscribeMessage('userAddsAnotherUserToRoom')

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -206,4 +206,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		);
 		client.emit('isRoomPasswordMatched', isMatched);
 	}
+
+	@SubscribeMessage('getNonMemberUsers')
+	async getNonMemberUsers(client: Socket, roomName: string) {
+		const response: UserI[] = await this.userService.getNonMemberUsers(
+			roomName,
+		);
+		client.emit('getNonMemberUsers', response);
+	}
 }

--- a/backend/src/gateway/chat.gateway.ts
+++ b/backend/src/gateway/chat.gateway.ts
@@ -214,4 +214,17 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		);
 		client.emit('getNonMemberUsers', response);
 	}
+
+	@SubscribeMessage('userAddsAnotherUserToRoom')
+	async userAddsAnotherUserToRoom(
+		@MessageBody() info: { userId: number; roomName: string },
+	) {
+		const room: RoomEntity = await this.roomService.findRoomByName(
+			info.roomName,
+		);
+		const user: UserI = await this.userService.findByID(info.userId);
+		await this.roomService.addVisitorToRoom(user.id, room);
+		// client.join(room.name); //FIXME how to join client sockets. client socket is different than the user being added
+		// await this.getPublicRoomsList(client); //FIXME how to refresh this in added users page?
+	}
 }

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -43,7 +43,7 @@ export class User {
 	@OneToMany(() => ConnectedUserEntity, (connection) => connection.user)
 	connections: ConnectedUserEntity[];
 
-	@OneToMany(() => UserToRoomEntity, (userToRoom) => userToRoom.room, {
+	@OneToMany(() => UserToRoomEntity, (userToRoom) => userToRoom.user, {
 		cascade: true,
 	})
 	public userToRooms!: UserToRoomEntity[];

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, Not } from 'typeorm';
 import User from './user.entity';
 import { CreateUserDto, UpdateUserProfileDto } from './dto';
 import { UserI } from './user.interface';
@@ -123,14 +123,14 @@ export class UserService {
 		return await this.getUserByID(userId);
 	}
 
-	async getNonMemberUsers(roomName: string): Promise<UserI[]> {
+	async getAllRegisteredUsersExceptYourselfAndAdmin(
+		userName: string,
+	): Promise<UserI[]> {
 		const userList = await this.userRepository
 			.createQueryBuilder('user')
-			.leftJoinAndSelect('user.userToRooms', 'userToRooms')
-			.leftJoinAndSelect('userToRooms.room', 'room')
-			.where('room.name != :roomName', { roomName })
+			.where({ username: Not(userName) })
+			.andWhere({ username: Not('admin') })
 			.getMany();
-		// console.log('user service\n', userList);
-		return userList; //FIXME atm this returns all the registered users
+		return userList;
 	}
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -124,23 +124,13 @@ export class UserService {
 	}
 
 	async getNonMemberUsers(roomName: string): Promise<UserI[]> {
-		//TODO do same query with roomName?
-		const room = await this.roomService.findRoomByName(roomName);
-		const roomId = room.id;
-		console.log(`${roomName}'s id is ${roomId}`);
 		const userList = await this.userRepository
 			.createQueryBuilder('user')
-			.leftJoinAndSelect(
-				'user.userToRooms',
-				'userToRooms',
-				'userToRooms.roomId = :roomId', //atm this get member users
-				{ roomId },
-			)
+			.leftJoinAndSelect('user.userToRooms', 'userToRooms')
+			.leftJoinAndSelect('userToRooms.room', 'room')
+			.where('room.name != :roomName', { roomName })
 			.getMany();
-		console.log('user service\n', userList);
-		return userList;
-		// .leftJoinAndSelect('userToRooms.room', 'room')
-		// .where('room.id = :roomId', { roomId })
-		// .where('room.name = :roomName', { roomName })
+		// console.log('user service\n', userList);
+		return userList; //FIXME atm this returns all the registered users
 	}
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -124,10 +124,23 @@ export class UserService {
 	}
 
 	async getNonMemberUsers(roomName: string): Promise<UserI[]> {
+		//TODO do same query with roomName?
+		const room = await this.roomService.findRoomByName(roomName);
+		const roomId = room.id;
+		console.log(`${roomName}'s id is ${roomId}`);
 		const userList = await this.userRepository
 			.createQueryBuilder('user')
+			.leftJoinAndSelect(
+				'user.userToRooms',
+				'userToRooms',
+				'userToRooms.roomId = :roomId', //atm this get member users
+				{ roomId },
+			)
 			.getMany();
-		console.log(userList);
+		console.log('user service\n', userList);
 		return userList;
+		// .leftJoinAndSelect('userToRooms.room', 'room')
+		// .where('room.id = :roomId', { roomId })
+		// .where('room.name = :roomName', { roomName })
 	}
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -122,4 +122,12 @@ export class UserService {
 		}
 		return await this.getUserByID(userId);
 	}
+
+	async getNonMemberUsers(roomName: string): Promise<UserI[]> {
+		const userList = await this.userRepository
+			.createQueryBuilder('user')
+			.getMany();
+		console.log(userList);
+		return userList;
+	}
 }

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -2,11 +2,17 @@
   <div>
     <Panel :header="$route.params.roomName">
       <template #icons>
-        <button class="p-panel-header-icon p-link mr-2" @click="onAddUserClick">
-          <span class="pi pi-users"></span>
-        </button>
+        <PrimeVueButton
+          label="Add User"
+          icon="pi pi-users"
+          @click="onAddUserClick"
+        />
       </template>
     </Panel>
+    <ChatBoxAddUsersDialogue
+      :isDialogVisible="displayAddUsersDialogue"
+      @update:isDialogVisible="displayAddUsersDialogue = $event"
+    />
     <ChatBoxUserProfileDialogue
       :isDialogVisible="displayUserProfileDialog"
       :clickedUserObject="clickedUser"
@@ -91,6 +97,7 @@ import UserProfileI from "../types/UserProfile.interface";
 import storeUser from "@/store";
 import ChatBoxUserProfileDialogue from "./ChatBoxUserProfileDialogue.vue";
 import { UserRole } from "@/types/UserRole.Enum";
+import ChatBoxAddUsersDialogue from "./ChatBoxAddUsersDialogue.vue";
 
 const socket: Socket = inject("socketioInstance");
 const messages = ref<Array<MessageI>>([]);
@@ -103,6 +110,7 @@ const computedID = computed(() => {
 }); //items ref params need a calculated property
 
 const displayUserProfileDialog = ref(false);
+const displayAddUsersDialogue = ref(false);
 
 const store = useStore();
 const currentRoom = computed(() =>
@@ -139,6 +147,11 @@ function sendMessage() {
 const addUserToRoom = () => {
   socket.emit("addUserToRoom", route.params.roomName);
 };
+
+function onAddUserClick() {
+  displayAddUsersDialogue.value = true;
+  console.log(displayAddUsersDialogue.value);
+}
 
 function onChipLeftClick(user: UserProfileI) {
   clickedUser.value = user;

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
-    <Panel>
-      {{ $route.params.roomName }}
+    <Panel :header="$route.params.roomName">
+      <template #icons>
+        <button class="p-panel-header-icon p-link mr-2" @click="onAddUserClick">
+          <span class="pi pi-users"></span>
+        </button>
+      </template>
     </Panel>
     <ChatBoxUserProfileDialogue
       :isDialogVisible="displayUserProfileDialog"

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -150,7 +150,6 @@ const addUserToRoom = () => {
 
 function onAddUserClick() {
   displayAddUsersDialogue.value = true;
-  console.log(displayAddUsersDialogue.value);
 }
 
 function onChipLeftClick(user: UserProfileI) {

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -13,7 +13,16 @@
       dataKey="id"
       @rowClick="onRow"
     >
-      <Column field="username" header="Users"> </Column>
+      <Column field="username" header="Users"></Column>
+      <Column field="isUser">
+        <template #body="slotProps">
+          <div>
+            <p v-if="checkIfUserIsInRoom(slotProps.data.username)">
+              already in room
+            </p>
+          </div>
+        </template>
+      </Column>
     </DataTable>
   </Dialog>
 </template>

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, defineEmits, defineProps, inject, computed } from "vue";
+import { ref, defineEmits, defineProps, inject } from "vue";
 import { Socket } from "socket.io-client";
 import { useRoute } from "vue-router";
 import Dialog from "primevue/dialog";

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -32,7 +32,7 @@ const props = defineProps(["isDialogVisible"]);
 const emit = defineEmits(["update:isDialogVisible"]);
 const userList = ref();
 
-socket.emit("getNonMemberUsers", "general");
+socket.emit("getNonMemberUsers", route.params.roomName);
 
 socket.on("getNonMemberUsers", (response) => {
   userList.value = response;

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -85,6 +85,10 @@ const checkIfUserIsInRoom = (userName: string) => {
 };
 
 const handleClose = () => {
+  socket.emit(
+    "getAllRegisteredUsersExceptYourselfAndAdmin",
+    route.params.roomName
+  );
   emit("update:isDialogVisible", false);
 };
 </script>

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -11,6 +11,7 @@
       scrollHeight="60vh"
       :row-hover="true"
       dataKey="id"
+      @rowClick="onRow"
     >
       <Column field="username" header="Users"> </Column>
     </DataTable>
@@ -20,19 +21,31 @@
 <script setup lang="ts">
 import { ref, defineEmits, defineProps, inject } from "vue";
 import { Socket } from "socket.io-client";
+import { useRoute } from "vue-router";
 import Dialog from "primevue/dialog";
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
 
 const socket: Socket = inject("socketioInstance");
+const route = useRoute();
 const props = defineProps(["isDialogVisible"]);
 const emit = defineEmits(["update:isDialogVisible"]);
 const userList = ref();
 
-socket.emit("getNonMemberUsers");
+socket.emit("getNonMemberUsers", "general");
+
 socket.on("getNonMemberUsers", (response) => {
   userList.value = response;
 });
+
+const onRow = (event) => {
+  const user = event.data;
+  console.log(`room ${route.params.roomName} user ${user.username} added?`);
+  socket.emit("userBeingAddedToRoom", {
+    userName: user.username,
+    roomName: route.params.roomName,
+  });
+};
 
 const handleClose = () => {
   emit("update:isDialogVisible", false);

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -4,10 +4,16 @@
     :style="{ width: '50vw' }"
     @update:visible="handleClose"
   >
-    <template #header>
-      <h3>Users</h3>
-    </template>
-    <DataTable :value="userList"> </DataTable>
+    <DataTable
+      :value="userList"
+      responsiveLayout="scroll"
+      :scrollable="true"
+      scrollHeight="60vh"
+      :row-hover="true"
+      dataKey="id"
+    >
+      <Column field="username" header="Users"> </Column>
+    </DataTable>
   </Dialog>
 </template>
 
@@ -16,6 +22,7 @@ import { ref, defineEmits, defineProps, inject } from "vue";
 import { Socket } from "socket.io-client";
 import Dialog from "primevue/dialog";
 import DataTable from "primevue/datatable";
+import Column from "primevue/column";
 
 const socket: Socket = inject("socketioInstance");
 const props = defineProps(["isDialogVisible"]);

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -44,10 +44,13 @@ const toast = useToast();
 const userList = ref();
 const roomWithUserRelations = ref();
 
-socket.emit(
-  "getAllRegisteredUsersExceptYourselfAndAdmin",
-  route.params.roomName
-);
+setTimeout(() => {
+  socket.emit(
+    "getAllRegisteredUsersExceptYourselfAndAdmin",
+    route.params.roomName
+  );
+}, 90);
+
 socket.on("getAllRegisteredUsersExceptYourselfAndAdmin", (response) => {
   userList.value = response;
 });

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -7,15 +7,18 @@
     <template #header>
       <h3>Users</h3>
     </template>
+    <DataTable :value="userList"> </DataTable>
   </Dialog>
 </template>
 
 <script setup lang="ts">
 import { ref, defineEmits, defineProps } from "vue";
 import Dialog from "primevue/dialog";
+import DataTable from "primevue/datatable";
 
 const props = defineProps(["isDialogVisible"]);
 const emit = defineEmits(["update:isDialogVisible"]);
+const userList = ref([]);
 
 const handleClose = () => {
   emit("update:isDialogVisible", false);

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -33,7 +33,7 @@ const props = defineProps(["isDialogVisible"]);
 const emit = defineEmits(["update:isDialogVisible"]);
 const toast = useToast();
 const userList = ref();
-const roomWithUserRole = ref();
+const roomWithUserRelations = ref();
 
 socket.emit(
   "getAllRegisteredUsersExceptYourselfAndAdmin",
@@ -45,7 +45,7 @@ socket.on("getAllRegisteredUsersExceptYourselfAndAdmin", (response) => {
 
 socket.emit("getOneRoomWithUserToRoomRelations", route.params.roomName);
 socket.on("getOneRoomWithUserToRoomRelations", (response) => {
-  roomWithUserRole.value = response;
+  roomWithUserRelations.value = response;
 });
 
 const onRow = (event) => {
@@ -63,11 +63,12 @@ const onRow = (event) => {
       userId: user.id,
       roomName: route.params.roomName,
     });
+    socket.emit("getOneRoomWithUserToRoomRelations", route.params.roomName);
   }
 };
 
 const checkIfUserIsInRoom = (userName: string) => {
-  for (var userToRoom of roomWithUserRole.value.userToRooms)
+  for (var userToRoom of roomWithUserRelations.value.userToRooms)
     if (userToRoom.user.username === userName) return true;
 };
 

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -41,8 +41,8 @@ socket.on("getNonMemberUsers", (response) => {
 const onRow = (event) => {
   const user = event.data;
   console.log(`room ${route.params.roomName} user ${user.username} added?`);
-  socket.emit("userBeingAddedToRoom", {
-    userName: user.username,
+  socket.emit("userAddsAnotherUserToRoom", {
+    userId: user.id,
     roomName: route.params.roomName,
   });
 };

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -19,32 +19,56 @@
 </template>
 
 <script setup lang="ts">
-import { ref, defineEmits, defineProps, inject } from "vue";
+import { ref, defineEmits, defineProps, inject, computed } from "vue";
 import { Socket } from "socket.io-client";
 import { useRoute } from "vue-router";
 import Dialog from "primevue/dialog";
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
+import { useToast } from "primevue/usetoast";
 
 const socket: Socket = inject("socketioInstance");
 const route = useRoute();
 const props = defineProps(["isDialogVisible"]);
 const emit = defineEmits(["update:isDialogVisible"]);
+const toast = useToast();
 const userList = ref();
+const roomWithUserRole = ref();
 
-socket.emit("getNonMemberUsers", route.params.roomName);
-
-socket.on("getNonMemberUsers", (response) => {
+socket.emit(
+  "getAllRegisteredUsersExceptYourselfAndAdmin",
+  route.params.roomName
+);
+socket.on("getAllRegisteredUsersExceptYourselfAndAdmin", (response) => {
   userList.value = response;
+});
+
+socket.emit("getOneRoomWithUserToRoomRelations", route.params.roomName);
+socket.on("getOneRoomWithUserToRoomRelations", (response) => {
+  roomWithUserRole.value = response;
 });
 
 const onRow = (event) => {
   const user = event.data;
-  console.log(`room ${route.params.roomName} user ${user.username} added?`);
-  socket.emit("userAddsAnotherUserToRoom", {
-    userId: user.id,
-    roomName: route.params.roomName,
-  });
+  if (checkIfUserIsInRoom(user.username)) {
+    toast.add({
+      severity: "error",
+      summary: "Error",
+      detail: "User is already in the room",
+      life: 1000,
+    });
+  } else {
+    console.log(`room ${route.params.roomName} user ${user.username} added`);
+    socket.emit("userAddsAnotherUserToRoom", {
+      userId: user.id,
+      roomName: route.params.roomName,
+    });
+  }
+};
+
+const checkIfUserIsInRoom = (userName: string) => {
+  for (var userToRoom of roomWithUserRole.value.userToRooms)
+    if (userToRoom.user.username === userName) return true;
 };
 
 const handleClose = () => {

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -12,13 +12,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, defineEmits, defineProps } from "vue";
+import { ref, defineEmits, defineProps, inject } from "vue";
+import { Socket } from "socket.io-client";
 import Dialog from "primevue/dialog";
 import DataTable from "primevue/datatable";
 
+const socket: Socket = inject("socketioInstance");
 const props = defineProps(["isDialogVisible"]);
 const emit = defineEmits(["update:isDialogVisible"]);
-const userList = ref([]);
+const userList = ref();
+
+socket.emit("getNonMemberUsers");
+socket.on("getNonMemberUsers", (response) => {
+  userList.value = response;
+});
 
 const handleClose = () => {
   emit("update:isDialogVisible", false);

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -1,0 +1,23 @@
+<template>
+  <Dialog
+    :visible="isDialogVisible"
+    :style="{ width: '50vw' }"
+    @update:visible="handleClose"
+  >
+    <template #header>
+      <h3>Users</h3>
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, defineEmits, defineProps } from "vue";
+import Dialog from "primevue/dialog";
+
+const props = defineProps(["isDialogVisible"]);
+const emit = defineEmits(["update:isDialogVisible"]);
+
+const handleClose = () => {
+  emit("update:isDialogVisible", false);
+};
+</script>


### PR DESCRIPTION
Frontend
- ChatBoxAddUsersDialogue is a child of ChatBox and becomes visible upon clicking AddUser button
- All the registered users are fetched from backend and displayed in the list. However, when someone is in the room, it says already in room. See the picture for slack implementation
- When a user row is clicked, it first checks if the user is in this room. If user is already a member, a toast error msg is displayed. If not, an event 'userAddsAnotherUserToRoom' to backend is sent.

Backend
- getAllRegisteredUsersExceptYourselfAndAdmin added to user service. Negative condition to get non member users did not work. So, this is the second best solution for fetching users to add to a room.
- getSpecificRoomWithUserToRoomRelations added to room service to send room info to frontend to check if a user is inside the room.
- Most important change with sockets and joining rooms: Atm, on handle connection each client joins a unique room called after their ids. this is needed to fetch all sockets of that user when a user adds another to user to that room
- userAddsAnotherUserToRoom first fetches all the socket instances of the user being added, then calls room service add visitor to room and afterwards in a loop of all of its socket instances, this user is joining the new room. Plus, getPublicRoomsList(socket) is called to refresh rooms in added users page to display input text instead of the join button.

Maybe: A filter search field might be nice to add but I don't think it is the priority atm.

Some resources: 
https://socket.io/docs/v4/server-instance/#fetchsockets

![Screenshot 2022-06-25 at 11 06 52](https://user-images.githubusercontent.com/57744064/175925178-37734b3a-9b0d-4f0a-be82-ab77174b1d81.png)
