### PR TITLE
158 channel banning users

### DIFF
--- a/backend/src/chat/room/dto/room.and.user.dto.ts
+++ b/backend/src/chat/room/dto/room.and.user.dto.ts
@@ -1,0 +1,8 @@
+import { IsNumber } from 'class-validator';
+
+export class RoomAndUserDTO {
+	@IsNumber()
+	userId: number;
+
+	roomName: string;
+}

--- a/backend/src/chat/room/entities/room.entity.ts
+++ b/backend/src/chat/room/entities/room.entity.ts
@@ -38,6 +38,6 @@ export class RoomEntity {
 	@OneToMany(() => MuteEntity, (mutes) => mutes.room, { cascade: true })
 	mutes: MuteEntity[];
 
-	@Column('simple-array', { array: true, default: [] })
+	@Column('simple-array', { default: [] })
 	bannedUserIds: number[];
 }

--- a/backend/src/chat/room/entities/room.entity.ts
+++ b/backend/src/chat/room/entities/room.entity.ts
@@ -38,6 +38,6 @@ export class RoomEntity {
 	@OneToMany(() => MuteEntity, (mutes) => mutes.room, { cascade: true })
 	mutes: MuteEntity[];
 
-	@Column({ default: [] })
+	@Column('simple-array', { array: true, default: [] })
 	bannedUserIds: number[];
 }

--- a/backend/src/chat/room/entities/room.entity.ts
+++ b/backend/src/chat/room/entities/room.entity.ts
@@ -37,4 +37,7 @@ export class RoomEntity {
 
 	@OneToMany(() => MuteEntity, (mutes) => mutes.room, { cascade: true })
 	mutes: MuteEntity[];
+
+	@Column({ default: [] })
+	bannedUserIds: number[];
 }

--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -350,7 +350,6 @@ export class RoomService {
 		);
 		room.mutes.push(newMute);
 		await this.roomEntityRepository.save(room);
-		console.log(room); //TODO remove
 	}
 
 	async checIfkMutedAndMuteDeadlineAndRemoveMute(
@@ -362,8 +361,6 @@ export class RoomService {
 			.where('room.name = :roomName', { roomName })
 			.leftJoinAndSelect('room.mutes', 'mutes')
 			.getOne();
-		console.log('room ', room); //TODO remove
-		console.log('mutes ', room.mutes); //TODO remove
 		const muteIndex = room.mutes.findIndex(
 			(element) => element.userId == userId,
 		);

--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -396,4 +396,14 @@ export class RoomService {
 		}
 		return true;
 	}
+
+	async isUserBanned(roomAndUser: RoomAndUserDTO) {
+		const room = await this.findRoomByName(roomAndUser.roomName);
+		const banIndex = room.bannedUserIds.findIndex(
+			(element) => element == roomAndUser.userId,
+		);
+		//check if user is already banned
+		if (banIndex == -1) return false;
+		else return true;
+	}
 }

--- a/backend/src/chat/room/room.service.ts
+++ b/backend/src/chat/room/room.service.ts
@@ -397,6 +397,21 @@ export class RoomService {
 		return true;
 	}
 
+	async unBanUserFromRoom(roomAndUser: RoomAndUserDTO, mutingUserId: number) {
+		const room = await this.findRoomByName(roomAndUser.roomName);
+		await this.userService.isOwnerOrAdmin(mutingUserId, room.id);
+		const banIndex = room.bannedUserIds.findIndex(
+			(element) => element == roomAndUser.userId,
+		);
+		//check if user is already banned
+		if (banIndex) {
+			// add user's id to banned users
+			room.bannedUserIds.splice(banIndex, 1);
+			await this.roomEntityRepository.save(room);
+			console.log(room); //TODO remove after PR
+		}
+	}
+
 	async isUserBanned(roomAndUser: RoomAndUserDTO) {
 		const room = await this.findRoomByName(roomAndUser.roomName);
 		const banIndex = room.bannedUserIds.findIndex(

--- a/backend/src/gateway/main.gateway.ts
+++ b/backend/src/gateway/main.gateway.ts
@@ -167,16 +167,18 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		this.server
 			.to(secondUserId.toString())
 			.emit('postPublicRoomsList', roomsList);
-		await this.getPublicRoomsList(client.data.user.id);
+		await this.getPublicRoomsList(client);
 	}
 
 	@SubscribeMessage('getPublicRoomsList')
-	async getPublicRoomsList(userId: number) {
-		const roomsList = await this.roomService.getPublicRoomsList(userId);
+	async getPublicRoomsList(client) {
+		const roomsList = await this.roomService.getPublicRoomsList(
+			client.data.user.id,
+		);
 		this.server
-			.to(userId.toString())
+			.to(client.data.user.id.toString())
 			.emit('postPublicRoomsList', roomsList);
-	} //TODO make sure Olga checks if it workds accordingly.
+	}
 
 	@SubscribeMessage('updateRoomPassword')
 	async updateRoomPassword(
@@ -187,7 +189,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			roomToUpdate.name,
 		);
 		await this.roomService.updateRoomPassword(room, roomToUpdate.password);
-		await this.getPublicRoomsList(client.data.user.id);
+		await this.getPublicRoomsList(client);
 	}
 
 	@SubscribeMessage('addUserToRoom')
@@ -207,7 +209,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		console.log(
 			`first time joining: ${client.data.user.username} w/${client.id} has joined room ${room.name}`,
 		);
-		await this.getPublicRoomsList(client.data.user.id);
+		await this.getPublicRoomsList(client);
 	}
 
 	@SubscribeMessage('removeUserFromRoom')
@@ -233,7 +235,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 				client.emit('room deleted', roomName);
 			}
 		} else {
-			await this.getPublicRoomsList(client.data.user.id);
+			await this.getPublicRoomsList(client);
 		}
 	}
 
@@ -247,7 +249,6 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		);
 		if (!user) console.log('exception'); //TODO throw exception
 		await this.roomService.muteUserInRoom(muteUser, client.data.user.id);
-		await this.getPublicRoomsList(muteUser.id);
 	}
 
 	@SubscribeMessage('banUserFromRoom')
@@ -263,8 +264,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			roomAndUser,
 			client.data.user.id,
 		);
-		await this.getPublicRoomsList(client.data.user.id);
-		await this.getPublicRoomsList(roomAndUser.userId); //FIXME input text should disappear immediately!
+		await this.getPublicRoomsList(client);
 	}
 
 	@SubscribeMessage('unBanUserFromRoom')
@@ -280,8 +280,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			roomAndUser,
 			client.data.user.id,
 		);
-		await this.getPublicRoomsList(client.data.user.id);
-		await this.getPublicRoomsList(roomAndUser.userId);
+		await this.getPublicRoomsList(client);
 	}
 
 	@SubscribeMessage('isUserBanned')
@@ -343,7 +342,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		for (const socket of sockets) {
 			socket.join(room.name); //joins each socket of the added user to this room
 			console.log(`${user.username} has been added to ${room.name}`);
-			await this.getPublicRoomsList(socket.data.user.id); //to refresh rooms in added users page
+			await this.getPublicRoomsList(socket); //to refresh rooms in added users page
 		}
 	}
 

--- a/backend/src/gateway/main.gateway.ts
+++ b/backend/src/gateway/main.gateway.ts
@@ -267,6 +267,22 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		await this.getPublicRoomsList(client);
 	}
 
+	@SubscribeMessage('unBanUserFromRoom')
+	async unBanUserFromRoom(
+		@MessageBody() roomAndUser: RoomAndUserDTO,
+		@ConnectedSocket() client: Socket,
+	) {
+		const user: UserI = await this.userService.findByID(
+			client.data.user.id,
+		);
+		if (!user) console.log('exception'); //TODO throw exception
+		await this.roomService.unBanUserFromRoom(
+			roomAndUser,
+			client.data.user.id,
+		);
+		await this.getPublicRoomsList(client);
+	}
+
 	@SubscribeMessage('isUserBanned')
 	async isUserBanned(
 		@MessageBody() roomAndUser: RoomAndUserDTO,

--- a/backend/src/gateway/main.gateway.ts
+++ b/backend/src/gateway/main.gateway.ts
@@ -180,6 +180,14 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			.emit('postPublicRoomsList', roomsList);
 	}
 
+	// @SubscribeMessage('getPublicRoomsList')
+	// async getPublicRoomsList(userId: number) {
+	// 	const roomsList = await this.roomService.getPublicRoomsList(userId);
+	// 	this.server
+	// 		.to(userId.toString())
+	// 		.emit('postPublicRoomsList', roomsList);
+	// } //TODO make sure Olga checks if it works accordingly.
+
 	@SubscribeMessage('updateRoomPassword')
 	async updateRoomPassword(
 		@ConnectedSocket() client: Socket,

--- a/backend/src/gateway/main.gateway.ts
+++ b/backend/src/gateway/main.gateway.ts
@@ -272,6 +272,13 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			roomAndUser,
 			client.data.user.id,
 		);
+		//leave the room with all the connected sockets
+		const sockets = await this.server
+			.in(roomAndUser.userId.toString())
+			.fetchSockets(); //fetches all connected sockets for this specific user
+		for (const socket of sockets) {
+			socket.leave(roomAndUser.roomName); //leaves each socket of the added user to this room
+		}
 		await this.getPublicRoomsList(client);
 	}
 

--- a/backend/src/gateway/main.gateway.ts
+++ b/backend/src/gateway/main.gateway.ts
@@ -167,18 +167,16 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		this.server
 			.to(secondUserId.toString())
 			.emit('postPublicRoomsList', roomsList);
-		await this.getPublicRoomsList(client);
+		await this.getPublicRoomsList(client.data.user.id);
 	}
 
 	@SubscribeMessage('getPublicRoomsList')
-	async getPublicRoomsList(client) {
-		const roomsList = await this.roomService.getPublicRoomsList(
-			client.data.user.id,
-		);
+	async getPublicRoomsList(userId: number) {
+		const roomsList = await this.roomService.getPublicRoomsList(userId);
 		this.server
-			.to(client.data.user.id.toString())
+			.to(userId.toString())
 			.emit('postPublicRoomsList', roomsList);
-	}
+	} //TODO make sure Olga checks if it workds accordingly.
 
 	@SubscribeMessage('updateRoomPassword')
 	async updateRoomPassword(
@@ -189,7 +187,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			roomToUpdate.name,
 		);
 		await this.roomService.updateRoomPassword(room, roomToUpdate.password);
-		await this.getPublicRoomsList(client);
+		await this.getPublicRoomsList(client.data.user.id);
 	}
 
 	@SubscribeMessage('addUserToRoom')
@@ -209,7 +207,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		console.log(
 			`first time joining: ${client.data.user.username} w/${client.id} has joined room ${room.name}`,
 		);
-		await this.getPublicRoomsList(client);
+		await this.getPublicRoomsList(client.data.user.id);
 	}
 
 	@SubscribeMessage('removeUserFromRoom')
@@ -235,7 +233,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 				client.emit('room deleted', roomName);
 			}
 		} else {
-			await this.getPublicRoomsList(client);
+			await this.getPublicRoomsList(client.data.user.id);
 		}
 	}
 
@@ -249,6 +247,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		);
 		if (!user) console.log('exception'); //TODO throw exception
 		await this.roomService.muteUserInRoom(muteUser, client.data.user.id);
+		await this.getPublicRoomsList(muteUser.id);
 	}
 
 	@SubscribeMessage('banUserFromRoom')
@@ -264,7 +263,8 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			roomAndUser,
 			client.data.user.id,
 		);
-		await this.getPublicRoomsList(client);
+		await this.getPublicRoomsList(client.data.user.id);
+		await this.getPublicRoomsList(roomAndUser.userId); //FIXME input text should disappear immediately!
 	}
 
 	@SubscribeMessage('unBanUserFromRoom')
@@ -280,7 +280,8 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			roomAndUser,
 			client.data.user.id,
 		);
-		await this.getPublicRoomsList(client);
+		await this.getPublicRoomsList(client.data.user.id);
+		await this.getPublicRoomsList(roomAndUser.userId);
 	}
 
 	@SubscribeMessage('isUserBanned')

--- a/backend/src/gateway/main.gateway.ts
+++ b/backend/src/gateway/main.gateway.ts
@@ -28,6 +28,7 @@ import { GameService } from '../game/game.service';
 import { CreateGameDto } from 'src/game/game.dto';
 import { MuteUserDto } from 'src/chat/room/dto/mute.user.dto';
 import { RoomVisibilityType } from 'src/chat/room/enums/room.visibility.enum';
+import { RoomAndUserDTO } from 'src/chat/room/dto/room.and.user.dto';
 
 @WebSocketGateway({
 	cors: { origin: 'http://localhost:8080', credentials: true },
@@ -248,6 +249,32 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		);
 		if (!user) console.log('exception'); //TODO throw exception
 		await this.roomService.muteUserInRoom(muteUser, client.data.user.id);
+	}
+
+	@SubscribeMessage('banUserFromRoom')
+	async banUserFromRoom(
+		@MessageBody() roomAndUser: RoomAndUserDTO,
+		@ConnectedSocket() client: Socket,
+	) {
+		const user: UserI = await this.userService.findByID(
+			client.data.user.id,
+		);
+		if (!user) console.log('exception'); //TODO throw exception
+		await this.roomService.banUserFromRoom(
+			roomAndUser,
+			client.data.user.id,
+		);
+		await this.getPublicRoomsList(client);
+	}
+
+	@SubscribeMessage('isUserBanned')
+	async isUserBanned(
+		@MessageBody() roomAndUser: RoomAndUserDTO,
+		@ConnectedSocket() client: Socket,
+	) {
+		const isUserBanned = await this.roomService.isUserBanned(roomAndUser);
+		console.log('is banned ', isUserBanned);
+		client.emit('isUserBanned', isUserBanned);
 	}
 
 	@SubscribeMessage('checkRoomPasswordMatch')

--- a/backend/src/gateway/main.gateway.ts
+++ b/backend/src/gateway/main.gateway.ts
@@ -343,7 +343,7 @@ export class MainGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		for (const socket of sockets) {
 			socket.join(room.name); //joins each socket of the added user to this room
 			console.log(`${user.username} has been added to ${room.name}`);
-			await this.getPublicRoomsList(socket); //to refresh rooms in added users page
+			await this.getPublicRoomsList(socket.data.user.id); //to refresh rooms in added users page
 		}
 	}
 

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -113,12 +113,9 @@ const clickedUser = ref<UserProfileI>(storeUser.state.user);
 const computedID = computed(() => {
   return clickedUser.value.id;
 }); //items ref params need a calculated property
+const isUserBanned = ref<boolean>();
 const computedIsUserBanned = computed(() => {
-  let isBanned;
-  socket.on("isUserBanned", (response) => {
-    isBanned = response;
-  });
-  return isBanned;
+  return isUserBanned.value;
 });
 
 const displayUserProfileDialog = ref(false);
@@ -140,6 +137,10 @@ onMounted(() => {
     if (route.params.roomName === message.room.name)
       messages.value.unshift(message);
   }); //place the new message on top of the messages arrayy
+
+  socket.on("isUserBanned", (response) => {
+    isUserBanned.value = response;
+  });
 });
 
 onUnmounted(() => {
@@ -205,7 +206,7 @@ const items = ref([
     visible: () =>
       isOwnerOrAdmin(currentRoom.value.userRole) &&
       isNotYourself(computedID.value) &&
-      isNotBanned(computedID.value),
+      !isBanned(computedID.value),
     command: () => banUserFromRoom(),
   },
   {
@@ -213,7 +214,7 @@ const items = ref([
     visible: () =>
       isOwnerOrAdmin(currentRoom.value.userRole) &&
       isNotYourself(computedID.value) &&
-      !isNotBanned(computedID.value),
+      isBanned(computedID.value),
     command: () => unBanUserFromRoom(),
   },
   {
@@ -271,13 +272,12 @@ const isOwnerOrAdmin = (userRole: UserRole | undefined) =>
   userRole < 2 ? true : false;
 const isNotYourself = (userID: number) =>
   userID === store.state.user.id ? false : true;
-const isNotBanned = (userID: number) => {
+const isBanned = (userID: number) => {
   socket.emit("isUserBanned", {
     userId: userID,
     roomName: route.params.roomName,
   });
-  if (computedIsUserBanned.value) return false;
-  else true;
+  return computedIsUserBanned.value;
 };
 </script>
 

--- a/frontend/src/components/ChatBox.vue
+++ b/frontend/src/components/ChatBox.vue
@@ -199,7 +199,7 @@ const items = ref([
       (isOwner(currentRoom.value.userRole) ||
         isAdmin(currentRoom.value.userRole)) &&
       isNotYourself(computedID.value),
-    command: () => socket.emit("banUserFromRoom"), //TODO pass user.id & room.name & add backend logic
+    command: () => banUserFromRoom(),
   },
   {
     label: "Mute user",
@@ -221,6 +221,19 @@ const muteUserInRoom = () => {
     severity: "success",
     summary: "Success",
     detail: "User has been muted",
+    life: 1000,
+  });
+};
+
+const banUserFromRoom = () => {
+  socket.emit("banUserFromRoom", {
+    userId: computedID.value,
+    roomName: route.params.roomName,
+  });
+  toast.add({
+    severity: "success",
+    summary: "Success",
+    detail: "User has been banned from room",
     life: 1000,
   });
 };

--- a/frontend/src/components/ChatBoxAddUsersDialogue.vue
+++ b/frontend/src/components/ChatBoxAddUsersDialogue.vue
@@ -70,7 +70,6 @@ const onRow = (event) => {
       life: 1000,
     });
   } else {
-    console.log(`room ${route.params.roomName} user ${user.username} added`);
     socket.emit("userAddsAnotherUserToRoom", {
       userId: user.id,
       roomName: route.params.roomName,


### PR DESCRIPTION
Banning:

- remove user relations from the room in the server side
- unjoin user's existing sockets from this specific room

Unbanning:

- remove the user id from the banned user array
- it is up to the user to join the room again

Frontend context menu visibility:

- with socket communication, get if a user is banned or not and display ban & unban & mute accordingly
- ATM, the banned user needs to refresh the page to see if it is banned or not. 

TODO: they will turn into separate issues
- Adjust add user part according to banned users as well. They should be able not added. Or display next to their name that they are banned.
- Add check for banned users to join logic. Adjust the join / inputText switch accordingly. Instead of two maybe display to the user that they are banned.